### PR TITLE
update for deployment on newer agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,13 @@ other methods.
 
 Or you can run `script/deploy` after `script/build` which will submit and start
 3 instances in whatever cluster your fleetctl config is pointing at.
+
+## Deployment
+
+## Automatic
+
+Merges to `master` will automatically be deployed to production.
+
+## Manual
+
+Standard fleetctl deployment is supported.

--- a/script/build
+++ b/script/build
@@ -16,7 +16,7 @@ DOCKER_IMAGE=$DOCKER_REPO:$IMAGE_TAG
 echo '--- building docker image'
 docker build -t $DOCKER_IMAGE .
 
-if [[ $CI = "true" && $BUILDKITE_BRANCH = "master" ]]; then
+if [ $CI = "true" ]; then
     echo '--- pushing docker image to registry'
     docker login -e="." -u="${QUAY_USERNAME}" -p="${QUAY_PASSWORD}" quay.io
     docker push $DOCKER_IMAGE
@@ -29,7 +29,7 @@ cp ${SERVICE}@.service.template ${SERVICE}@.service
 
 perl -p -i -e "s|^Environment=DOCKER_IMAGE=.*$|Environment=DOCKER_IMAGE=${DOCKER_IMAGE}|" ${SERVICE}@.service
 
-if [[ $CI = "true" && $BUILDKITE_BRANCH = "master" ]]; then
+if hash buildkite-agent 2>/dev/null ; then
   echo '--- saving service file'
   buildkite-agent artifact upload ${SERVICE}@.service
 fi

--- a/script/deploy
+++ b/script/deploy
@@ -14,20 +14,12 @@ if [[ ! -e ${SERVICE}@.service ]]; then
   exit 1
 fi
 
-if [[ ! -e $PEM_FILE ]]; then
-  echo "Please provide a .pem file for the fleet"
-  exit 1
-fi
-
-eval "$(ssh-agent -s)"
-ssh-add $PEM_FILE
-
-fleetctl --strict-host-key-checking=false destroy ${SERVICE}@.service
+fleetctl --strict-host-key-checking=false destroy ${SERVICE}@.service || true
 fleetctl --strict-host-key-checking=false submit ${SERVICE}@.service
 
 echo '--- (re-)starting fleet service instances'
 for i in {1..3}; do
-  fleetctl --strict-host-key-checking=false destroy ${SERVICE}@$i
+  fleetctl --strict-host-key-checking=false destroy ${SERVICE}@$i || true
   fleetctl --strict-host-key-checking=false start ${SERVICE}@$i
   # TODO: Use consul to see if ${SERVICE}@$i is healthy yet before moving on
 done


### PR DESCRIPTION
@tie-rack I've got the BuildKite pipeline for this partially updated to make the transition. The old steps are now renamed with "legacy" and the new steps are in place. Deployment is current restricted in both legacy and new by branch filtering on NONE, but the plan will be to only selectively deploy to staging, and turn master branch filtering on deploy to production.

Once this is approved, I'll remove legacy steps, turn master branch deploys on production, and merge this.